### PR TITLE
Use `pathlib` for OS agnosticism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run Tests
-        run: |
-          pip install coverage
-          coverage run -m pytest
-      - name: Upload coverage
-        uses: paambaati/codeclimate-action@v3.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          coverageCommand: coverage xml
+        run: python -m pytest
+      #   Something weird going on with CodeClimate, we can
+      #   add code coverage later
+      #   run: |
+      #     pip install coverage
+      #     coverage run -m pytest
+      # - name: Upload coverage
+      #   uses: paambaati/codeclimate-action@v3.0.0
+      #   env:
+      #     CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      #   with:
+      #     coverageCommand: coverage xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,11 @@ jobs:
           pip install -r requirements.txt
       - name: Run Tests
         run: |
-          python -m pytest
+          pip install coverage
+          coverage run -m pytest
+      - name: Upload coverage
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        with:
+          coverageCommand: coverage xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .idea
 .DS_Store
 tests/test_renders/*
+.venv/

--- a/rna_draw/colorer.py
+++ b/rna_draw/colorer.py
@@ -31,7 +31,6 @@ class Colorer(object):
     def get_rgb_colors(
         self, seq, ss, color_str=None, data=None, render_type=None, default_color=None
     ):
-
         if default_color is None:
             default_color = COLORS["e"]
 

--- a/rna_draw/draw.py
+++ b/rna_draw/draw.py
@@ -3,6 +3,7 @@ import time
 import argparse
 import pandas as pd
 from scipy.optimize import curve_fit
+from pathlib import Path
 
 from rna_draw import render_rna, parameters, colorer
 from rna_draw.colorer import *
@@ -206,6 +207,8 @@ def rna_draw(**kwargs):
     args = []
     for k, v in kwargs.items():
         args.append("-" + k)
+        if (isinstance(v, Path)):
+            v = str(v)
         args.append(v)
     args = parser.parse_args(args)
     return __rna_draw_from_args(args)

--- a/rna_draw/draw.py
+++ b/rna_draw/draw.py
@@ -85,7 +85,6 @@ class RNADrawer(object):
         data=None,
         draw_params=None,
     ):
-
         self.__setup(draw_params)
 
         if seq is None:
@@ -207,7 +206,7 @@ def rna_draw(**kwargs):
     args = []
     for k, v in kwargs.items():
         args.append("-" + k)
-        if (isinstance(v, Path)):
+        if isinstance(v, Path):
             v = str(v)
         args.append(v)
     args = parser.parse_args(args)

--- a/rna_draw/render_rna.py
+++ b/rna_draw/render_rna.py
@@ -68,13 +68,11 @@ def get_pairmap_from_secstruct(secstruct):
 
 
 def add_nodes_recursive(bi_pairs, rootnode, start_index, end_index):
-
     if start_index > end_index:
         print("Error occured while drawing RNA %d %d" % (start_index, end_index))
         sys.exit(0)
 
     if bi_pairs[start_index] == end_index:
-
         newnode = RNATreeNode()
         newnode.is_pair_ = True
         newnode.index_a_ = start_index
@@ -83,7 +81,6 @@ def add_nodes_recursive(bi_pairs, rootnode, start_index, end_index):
         add_nodes_recursive(bi_pairs, newnode, start_index + 1, end_index - 1)
 
     else:
-
         newnode = RNATreeNode()
         jj = start_index
         while jj <= end_index:
@@ -111,7 +108,6 @@ def setup_coords_recursive(
     PRIMARY_SPACE,
     PAIR_SPACE,
 ):
-
     cross_x = -go_y
     cross_y = go_x
 
@@ -165,7 +161,6 @@ def setup_coords_recursive(
             )
 
     elif len(rootnode.children_) > 1:
-
         npairs = 0
         for ii in range(0, len(rootnode.children_)):
             if rootnode.children_[ii].is_pair_:
@@ -185,7 +180,6 @@ def setup_coords_recursive(
             rootnode.y_ = parentnode.y_ + go_y * circle_radius
 
         for ii in range(0, len(rootnode.children_)):
-
             length_walker += PRIMARY_SPACE
 
             if rootnode.children_[ii].is_pair_:
@@ -257,7 +251,6 @@ class RNARenderer:
         self.ax = self.fig.add_subplot(111, aspect="equal")
 
     def setup_tree(self, secstruct, NODE_R, PRIMARY_SPACE, PAIR_SPACE):
-
         dangling_start = 0
         dangling_end = 0
         bi_pairs = get_pairmap_from_secstruct(secstruct)
@@ -333,7 +326,6 @@ class RNARenderer:
         self, offset_x, offset_y, colors, pairs, sequence, render_in_letter, line=False
     ):
         if self.xarray_ != None:
-
             if line:
                 for ii in range(len(self.xarray_) - 1):
                     if colors == None:
@@ -341,7 +333,6 @@ class RNARenderer:
                     else:
                         pass
             else:
-
                 if pairs:
                     for pair in pairs:
                         x1, y1 = (
@@ -394,7 +385,6 @@ class RNARenderer:
                             )
                             self.ax.add_patch(cir)
                 if sequence:
-
                     for ii in range(0, len(self.xarray_)):
                         if not render_in_letter:
                             text_size = 20
@@ -423,7 +413,6 @@ class RNARenderer:
                         )
 
     def get_coords(self, xarray, yarray, PRIMARY_SPACE, PAIR_SPACE):
-
         if self.root_ != None:
             get_coords_recursive(self.root_, xarray, yarray, PRIMARY_SPACE, PAIR_SPACE)
         else:

--- a/rna_draw/settings.py
+++ b/rna_draw/settings.py
@@ -1,12 +1,10 @@
 import os
 import platform
+from pathlib import Path
 
 
 def get_lib_path():
-    file_path = os.path.realpath(__file__)
-    spl = file_path.split("/")
-    base_dir = "/".join(spl[:-2])
-    return base_dir
+    return Path(__file__).parent.parent
 
 
 def get_os():
@@ -22,6 +20,6 @@ def get_os():
 
 class Paths:
     LIB_PATH = get_lib_path()
-    RESOURCES_PATH = LIB_PATH + "/rna_draw/resources/"
-    UNITTEST_PATH = LIB_PATH + "/tests/"
-    EXAMPLE_PATH = LIB_PATH + "/examples/"
+    RESOURCES_PATH = LIB_PATH/"rna_draw/resources/"
+    UNITTEST_PATH = LIB_PATH/"tests/"
+    EXAMPLE_PATH = LIB_PATH/"examples/"

--- a/rna_draw/settings.py
+++ b/rna_draw/settings.py
@@ -20,6 +20,6 @@ def get_os():
 
 class Paths:
     LIB_PATH = get_lib_path()
-    RESOURCES_PATH = LIB_PATH/"rna_draw/resources/"
-    UNITTEST_PATH = LIB_PATH/"tests/"
-    EXAMPLE_PATH = LIB_PATH/"examples/"
+    RESOURCES_PATH = LIB_PATH / "rna_draw/resources/"
+    UNITTEST_PATH = LIB_PATH / "tests/"
+    EXAMPLE_PATH = LIB_PATH / "examples/"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,8 +11,8 @@ class DataUnittest(unittest.TestCase):
             self.assertTrue(d.vals == vals)
 
         with self.subTest("load data from file"):
-            path = settings.Paths.UNITTEST_PATH + "/"
-            d = data.Data(data_file=path + "resources/test_data_file.dat")
+            path = settings.Paths.UNITTEST_PATH
+            d = data.Data(data_file=path/"resources/test_data_file.dat")
             self.assertTrue(d.vals == vals)
 
     def test_min_max(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,7 +12,7 @@ class DataUnittest(unittest.TestCase):
 
         with self.subTest("load data from file"):
             path = settings.Paths.UNITTEST_PATH
-            d = data.Data(data_file=path/"resources/test_data_file.dat")
+            d = data.Data(data_file=path / "resources/test_data_file.dat")
             self.assertTrue(d.vals == vals)
 
     def test_min_max(self):

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -3,31 +3,31 @@ import unittest
 import rna_draw as rd
 from rna_draw import settings
 
-path = settings.Paths.UNITTEST_PATH + "/"
+path = settings.Paths.UNITTEST_PATH
 
 
 class Unittest(unittest.TestCase):
     def test_basic(self):
-        rd.rna_draw(ss="(....)", seq="CUUCGG", out=path + "test_renders/test_1")
+        rd.rna_draw(ss="(....)", seq="CUUCGG", out=path/"test_renders/test_1")
 
         rd.rna_draw(
             ss="(....)",
             seq="CUUCGG",
-            out=path + "test_renders/test_2",
+            out=path/"test_renders/test_2",
             color_str="1-6:r",
         )
 
         rd.rna_draw(
             ss="(....)",
             seq="CUUCGG",
-            out=path + "test_renders/test_3",
+            out=path/"test_renders/test_3",
             render_type="res_type",
         )
 
         rd.rna_draw(
             ss="(....)",
             seq="CUUCGG",
-            out=path + "test_renders/test_4",
+            out=path/"test_renders/test_4",
             default_color="g",
         )
 
@@ -38,14 +38,14 @@ class Unittest(unittest.TestCase):
 
         with self.subTest("simplest data use"):
             rd.rna_draw(
-                ss=ss, seq=seq, out=path + "test_renders/test_5", data_str=data_str
+                ss=ss, seq=seq, out=path/"test_renders/test_5", data_str=data_str
             )
 
         with self.subTest("ignore restypes"):
             rd.rna_draw(
                 ss=ss,
                 seq=seq,
-                out=path + "test_renders/test_6",
+                out=path/"test_renders/test_6",
                 data_str=data_str,
                 data_ignore_restype="A",
             )
@@ -54,7 +54,7 @@ class Unittest(unittest.TestCase):
             rd.rna_draw(
                 ss=ss,
                 seq=seq,
-                out=path + "test_renders/test_7",
+                out=path/"test_renders/test_7",
                 data_str=data_str,
                 data_ignore_restype="GCU",
             )

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -8,26 +8,26 @@ path = settings.Paths.UNITTEST_PATH
 
 class Unittest(unittest.TestCase):
     def test_basic(self):
-        rd.rna_draw(ss="(....)", seq="CUUCGG", out=path/"test_renders/test_1")
+        rd.rna_draw(ss="(....)", seq="CUUCGG", out=path / "test_renders/test_1")
 
         rd.rna_draw(
             ss="(....)",
             seq="CUUCGG",
-            out=path/"test_renders/test_2",
+            out=path / "test_renders/test_2",
             color_str="1-6:r",
         )
 
         rd.rna_draw(
             ss="(....)",
             seq="CUUCGG",
-            out=path/"test_renders/test_3",
+            out=path / "test_renders/test_3",
             render_type="res_type",
         )
 
         rd.rna_draw(
             ss="(....)",
             seq="CUUCGG",
-            out=path/"test_renders/test_4",
+            out=path / "test_renders/test_4",
             default_color="g",
         )
 
@@ -38,14 +38,14 @@ class Unittest(unittest.TestCase):
 
         with self.subTest("simplest data use"):
             rd.rna_draw(
-                ss=ss, seq=seq, out=path/"test_renders/test_5", data_str=data_str
+                ss=ss, seq=seq, out=path / "test_renders/test_5", data_str=data_str
             )
 
         with self.subTest("ignore restypes"):
             rd.rna_draw(
                 ss=ss,
                 seq=seq,
-                out=path/"test_renders/test_6",
+                out=path / "test_renders/test_6",
                 data_str=data_str,
                 data_ignore_restype="A",
             )
@@ -54,7 +54,7 @@ class Unittest(unittest.TestCase):
             rd.rna_draw(
                 ss=ss,
                 seq=seq,
-                out=path/"test_renders/test_7",
+                out=path / "test_renders/test_7",
                 data_str=data_str,
                 data_ignore_restype="GCU",
             )


### PR DESCRIPTION
This PR originally tried to add test coverage, but CodeClimate is being touchy, so let's put a pin in that.

This PR implements pathlib so that the build can work on all operating systems. This should mean that the project itself is also more amenable to multiple operating systems.